### PR TITLE
chore: bump version to 1.7.1

### DIFF
--- a/lib/pages/wallet/walletPage.dart
+++ b/lib/pages/wallet/walletPage.dart
@@ -13,7 +13,7 @@ class WalletPage extends GetView<WalletPageController> {
           style: TextStyle(
             fontSize: 18,
             fontWeight: FontWeight.w400,
-            color: Theme.of(context).extension<CustomColors>()!.primaryLv1!,
+            color: Theme.of(context).extension<CustomColors>()!.primary700!,
           ),
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.7.0+38
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.18.2 <3.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # Read more about iOS versioning at
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 
-version: 1.7.0+38
+version: 1.7.1+38
 
 environment:
   sdk: ">=2.18.2 <3.0.0"


### PR DESCRIPTION
## Notable Changes
* fix color key error in wallet page
* update dart constraint (>=2.18.2 < 3.0.0, due to [`fcl_flutter`](https://github.com/mirror-media/fcl_flutter) package)
* chore: bump version to 1.7.1